### PR TITLE
fix(spinner): spinner to use alt instead of aria-label

### DIFF
--- a/.changeset/angry-horses-judge.md
+++ b/.changeset/angry-horses-judge.md
@@ -1,0 +1,5 @@
+---
+'@zopauk/react-components': minor
+---
+
+Spinner swap aria label for alt

--- a/package.json
+++ b/package.json
@@ -165,5 +165,5 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "packageManager": "pnpm@9.1.1"
+  "packageManager": "pnpm@9.1.4"
 }

--- a/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`<Button /> renders loading as "primary" 1`] = `
   theme="[object Object]"
 >
   <img
-    aria-label="loading spinner"
+    alt="loading spinner"
     height="20px"
     src="spinner-negative.gif"
     width="20px"
@@ -276,7 +276,7 @@ exports[`<Button /> renders loading as "secondary" 1`] = `
   theme="[object Object]"
 >
   <img
-    aria-label="loading spinner"
+    alt="loading spinner"
     height="20px"
     src="spinner-action.gif"
     width="20px"
@@ -334,7 +334,7 @@ exports[`<Button /> renders loading as "secondary" 2`] = `
   theme="[object Object]"
 >
   <img
-    aria-label="loading spinner"
+    alt="loading spinner"
     height="20px"
     src="spinner-action.gif"
     width="20px"

--- a/src/components/atoms/RoundButton/__snapshots__/RoundButton.test.tsx.snap
+++ b/src/components/atoms/RoundButton/__snapshots__/RoundButton.test.tsx.snap
@@ -419,7 +419,7 @@ exports[`<RoundButton /> renders loading as "primary" 1`] = `
     class="round-button-circle"
   >
     <img
-      aria-label="loading spinner"
+      alt="loading spinner"
       height="20px"
       src="spinner-negative.gif"
       width="20px"
@@ -531,7 +531,7 @@ exports[`<RoundButton /> renders loading as "secondary" 1`] = `
     class="round-button-circle"
   >
     <img
-      aria-label="loading spinner"
+      alt="loading spinner"
       height="20px"
       src="spinner-action.gif"
       width="20px"

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -44,7 +44,7 @@ const Spinner = (props: SpinnerProps) => {
   return theme.spinner.spinnerTheme !== 'zopa' && theme.spinner.customSpinner ? (
     <CustomSpinner size={props.size} styling={props.styling} />
   ) : (
-    <img src={spinner} height={size} width={size} aria-label="loading spinner" />
+    <img src={spinner} height={size} width={size} alt="loading spinner" />
   );
 };
 

--- a/src/components/atoms/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/atoms/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Spinner /> renders a spinner 1`] = `
 <img
-  aria-label="loading spinner"
+  alt="loading spinner"
   height="40px"
   src="spinner-brand.gif"
   width="40px"
@@ -11,7 +11,7 @@ exports[`<Spinner /> renders a spinner 1`] = `
 
 exports[`<Spinner /> renders negative 1`] = `
 <img
-  aria-label="loading spinner"
+  alt="loading spinner"
   height="40px"
   src="spinner-negative.gif"
   width="40px"
@@ -20,7 +20,7 @@ exports[`<Spinner /> renders negative 1`] = `
 
 exports[`<Spinner /> renders small 1`] = `
 <img
-  aria-label="loading spinner"
+  alt="loading spinner"
   height="20px"
   src="spinner-brand.gif"
   width="20px"


### PR DESCRIPTION
Using alt on img tag is more appropriate that using aria-label as alt is for graphic context