### PR TITLE
Remove override from flex-container - move to template

### DIFF
--- a/.changeset/thick-apples-smile.md
+++ b/.changeset/thick-apples-smile.md
@@ -1,0 +1,5 @@
+---
+'@zopauk/react-components': minor
+---
+
+Updated flexContainer behaviour

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/src/components/layout/FlexContainer/FlexContainer.tsx
+++ b/src/components/layout/FlexContainer/FlexContainer.tsx
@@ -1,8 +1,6 @@
-import classnames from 'classnames';
 import React from 'react';
 import styled from 'styled-components';
 import { grid } from '../../../constants';
-import { useThemeContext } from '../../styles/Theme';
 
 export interface FlexContainerGutter {
   gutter?: number;
@@ -32,10 +30,7 @@ const StyledFlexContainer = styled.div<FlexContainerProps>`
 `;
 
 const FlexContainer = ({ gutter = grid.gutter, ...rest }: FlexContainerProps) => {
-  const themeContext = useThemeContext();
-  return (
-    <StyledFlexContainer gutter={gutter} className={classnames(themeContext.flexContainer?.className)} {...rest} />
-  );
+  return <StyledFlexContainer gutter={gutter} {...rest} />;
 };
 
 export default FlexContainer;

--- a/src/components/styles/Theme/ThemeProvider.tsx
+++ b/src/components/styles/Theme/ThemeProvider.tsx
@@ -411,7 +411,6 @@ export interface AppTheme {
   productTemplate?: ProductTemplate;
   productTemplateV2?: ProductTemplateV2;
   radio: RadioTheme;
-  flexContainer?: FlexContainerTheme;
   option?: OptionTheme;
   sitTight?: SitTightTheme;
 }

--- a/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplateV2.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplateV2.tsx
@@ -20,6 +20,8 @@ export interface ProductTemplateV2 {
   row?: {
     className: string;
   };
+  /* What is the width of the content for the form */
+  flexContainerClassName?: string;
 }
 type HeaderProps = {
   title?: React.ReactNode;
@@ -59,16 +61,18 @@ const HeaderContainer = styled.div`
 function ProductTemplate({ header, children }: ProductTemplateProps) {
   const theme = useThemeContext();
 
-  const templateClassName = theme?.productTemplateV2?.row?.className;
-
   return (
     <Content className="mb-8">
       <HeaderContainer className="product-template-header-container">
         <Header {...header} />
       </HeaderContainer>
-      <FlexContainer data-automation="ZA.ProductTemplateV2.Container" gutter={0}>
+      <FlexContainer
+        data-automation="ZA.ProductTemplateV2.Container"
+        className={classnames(theme?.productTemplateV2?.flexContainerClassName)}
+        gutter={0}
+      >
         <FlexRow
-          className={classnames(templateClassName || 'px-6 m:px-0', 'product-template-row')}
+          className={classnames(theme?.productTemplateV2?.row?.className || 'px-6 m:px-0', 'product-template-row')}
           gutter={0}
           justify="center"
         >


### PR DESCRIPTION
Allow overriding the template `flexContainer`, but not the global `flexContainer`